### PR TITLE
Increased the amount of hit per level from 1 to 1.5

### DIFF
--- a/src/map/pc.hpp
+++ b/src/map/pc.hpp
@@ -1235,7 +1235,7 @@ enum e_mado_type : uint16 {
 	#define pc_leftside_matk(sd) (status_base_matk_min(&(sd)->bl, status_get_status_data((sd)->bl), (sd)->status.base_level))
 	#define pc_rightside_matk(sd) ((sd)->battle_status.rhw.matk+(sd)->battle_status.lhw.matk+(sd)->bonus.ematk)
 #else
-	#define pc_leftside_atk(sd) ((sd)->battle_status.batk + (sd)->battle_status.rhw.atk + (sd)->battle_status.lhw.atk)
+	#define pc_leftside_atk(sd) (((sd)->battle_status.batk + (sd)->battle_status.rhw.atk + (sd)->battle_status.lhw.atk)* (100 + (sd)->bonus.atk_rate) / 100)
 	#define pc_rightside_atk(sd) ((sd)->battle_status.rhw.atk2 + (sd)->battle_status.lhw.atk2)
 	#define pc_leftside_def(sd) ((sd)->battle_status.def)
 	#define pc_rightside_def(sd) ((sd)->battle_status.def2)


### PR DESCRIPTION
Every build needs dex for no reason other than the Hit it provides. This change removes the need to add points there in favor of more interesting stats for most cases.